### PR TITLE
Add /target to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 
+/target


### PR DESCRIPTION
The deploy process generates a lot of content in /target that should be ignored by git.
