### PR TITLE
Application summary researcher status & rationale

### DIFF
--- a/src/app/admin-manage/admin-manage-access.controller.js
+++ b/src/app/admin-manage/admin-manage-access.controller.js
@@ -67,8 +67,9 @@
             cmElectionService.downloadDatasetVotesForDARElection(dataRequestId);
         }
 
-        function openApplication(dar_id) {
+        function openApplication(dar_id, electionStatus) {
             $scope.dataRequestId = dar_id;
+            $scope.electionStatus = electionStatus;
             $modal.open({
                 animation: false,
                 templateUrl: 'app/modals/application-summary-modal/application-summary-modal.html',

--- a/src/app/admin-manage/admin-manage-access.html
+++ b/src/app/admin-manage/admin-manage-access.html
@@ -41,7 +41,7 @@
                             <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 pvotes-list-id">{{dar.createDate | date:'yyyy-MM-dd'}}
                             </div>
                             <a href="" class="admin-manage-buttons col-lg-1 col-md-1 col-sm-1 col-xs-1 no-padding">
-                                <div class="enabled hover-color" ng-click="AdminManageAccess.openApplication(dar.dataRequestId)">
+                                <div class="enabled hover-color" ng-click="AdminManageAccess.openApplication(dar.dataRequestId, dar.electionStatus)">
                                     <span>Summary</span>
                                 </div>
                             </a>

--- a/src/app/data-owner-review/data-owner-review.controller.js
+++ b/src/app/data-owner-review/data-owner-review.controller.js
@@ -38,6 +38,7 @@
 
 
         function openApplication(){
+             $scope.electionStatus = 'Closed';
              $modal.open({
                 animation: false,
                 templateUrl: 'app/modals/application-summary-modal/application-summary-modal.html',

--- a/src/app/modals/application-summary-modal/application-summary-modal.controller.js
+++ b/src/app/modals/application-summary-modal/application-summary-modal.controller.js
@@ -9,7 +9,18 @@
 
         $scope.calledFromAdmin = calledFromAdmin;
         $scope.summary = darDetails;
+        $scope.bonafideResearcher = "Bonafide researcher";
+        $scope.nonBonafide = "Non-Bonafide researcher";
+        $scope.pendingForReview = "Pending for review";
+
         var vm = this;
+        if(darDetails.status === "pending"){
+            darDetails.status = $scope.pendingForReview;
+        } else if(darDetails.status === "rejected") {
+            darDetails.status = $scope.nonBonafide;
+        } else {
+            darDetails.status = $scope.bonafideResearcher;
+        }
 
         vm.ok = function () {
             $modalInstance.close();
@@ -30,6 +41,13 @@
             researcher: false
         };
 
+        vm.rationaleCheck = function () {
+            if($scope.summary.rationale !== null && $scope.summary.rationale !== '' && $scope.summary.rationale !== undefined) {
+                return true;
+            } else {
+                return false;
+            }
+        };
     }
 
 })();

--- a/src/app/modals/application-summary-modal/application-summary-modal.html
+++ b/src/app/modals/application-summary-modal/application-summary-modal.html
@@ -16,9 +16,16 @@
                     <label class="col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label access-color">Principal Investigator</label>
                     <div class="col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label">{{summary.principalInvestigator}}</div>
                 </div>
-                <div ng-if="calledFromAdmin" class="row">
+                <div class="row">
                     <label class="col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label access-color">Researcher</label>
-                    <div class="col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label">{{summary.researcherName}}</div>
+                    <div class="col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label">{{summary.researcherName}}
+                        <div ng-if = "electionStatus != 'Closed'">
+                            <B>Status: </B>{{summary.status}}
+                            <div ng-if="ApplicationModal.rationaleCheck() && summary.status === bonafideResearcher"><b>Comment: </b>{{summary.rationale}}</div>
+                            <div ng-if="ApplicationModal.rationaleCheck() && summary.status !== bonafideResearcher"><b>Rationale: </b>{{summary.rationale}}</div>
+                        </div>
+
+                    </div>
                 </div>
                 <div class="row">
                     <label class="col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label access-color">Institution Name</label>

--- a/src/app/results-record/access-results-record.controller.js
+++ b/src/app/results-record/access-results-record.controller.js
@@ -284,6 +284,7 @@
         }
 
         $scope.openApplication = function openApplication() {
+            $scope.electionStatus = 'Closed';
             var modalInstance = $modal.open({
                 animation: false,
                 templateUrl: 'app/modals/application-summary-modal/application-summary-modal.html',

--- a/src/app/review-results/access-review-results.controller.js
+++ b/src/app/review-results/access-review-results.controller.js
@@ -86,6 +86,7 @@
 
         function openApplication() {
             $scope.dataRequestId = dar_id;
+            $scope.electionStatus = 'Open';
             $modal.open({
                 animation: false,
                 templateUrl: 'app/modals/application-summary-modal/application-summary-modal.html',

--- a/src/app/review-results/final-access-review-results.controller.js
+++ b/src/app/review-results/final-access-review-results.controller.js
@@ -134,6 +134,7 @@
         }
 
         function openApplication() {
+            $scope.electionStatus = 'Final';
             var modalInstance = $modal.open({
                 animation: false,
                 templateUrl: 'app/modals/application-summary-modal/application-summary-modal.html',

--- a/src/app/review/access-review.controller.js
+++ b/src/app/review/access-review.controller.js
@@ -45,6 +45,7 @@
 
         function openApplication() {
             $scope.dataRequestId = dar_id;
+            $scope.electionStatus = election.electionStatus;
             $modal.open({
                 animation: false,
                 templateUrl: 'app/modals/application-summary-modal/application-summary-modal.html',


### PR DESCRIPTION
Researcher status is now added in all modals where it is required.

A scope is added in the controllers to check if the selection is closed or not, so we can define if researcher status is to be shown or not. If it is closed it wont be displayed.

If the status of the researcher has a rationale or a comment, it will be displayed below the status, if it doesn't have a rationale/comment, the label will hide, only showing the status. 
