### PR TITLE
GAWB-3152: http-server dep to 0.10.0, which brings transitive ecstatic to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ConsentManagement",
   "version": "0.0.0",
   "dependencies": {
-    "http-server": "0.9.0"
+    "http-server": "0.10.0"
   },
   "scripts": {
     "postinstall": "bower install; gulp",


### PR DESCRIPTION
objective is to upgrade the `ecstatic` dependency to at least 2.0.0, due to proactive warnings from automated security scans.

`ecstatic` is a transitive dependency. Instead of mucking with npm shrinkwrap or otherwise overriding dependencies, I just upgraded `http-server` to 0.10.0, which brings in `ecstatic` 2.0.0. I was aiming to keep code changes small and unobtrusive. At some future point, we should consider shrinkwrapping the dependencies for more granular control.