### PR TITLE
GAWB-3291: Show match failure error in UI

### DIFF
--- a/src/app/results-record/access-results-record.controller.js
+++ b/src/app/results-record/access-results-record.controller.js
@@ -271,7 +271,11 @@
 
         function vaultVote(consentId) {
             cmMatchService.findMatch(consentId, $scope.electionAccess.referenceId).then(function (data) {
-                if (data.match !== null && data.match !== undefined) {
+                if (data.failed !== null && data.failed !== undefined && data.failed) {
+                    $scope.hideMatch = false;
+                    $scope.match = "-1";
+                    $scope.createDate = data.createDate;
+                } else if (data.match !== null && data.match !== undefined) {
                     $scope.hideMatch = false;
                     $scope.match = data.match;
                     $scope.createDate = data.createDate;

--- a/src/app/results-record/access-results-record.html
+++ b/src/app/results-record/access-results-record.html
@@ -196,6 +196,7 @@
                                 <span ng-if="match == '1'">YES</span>
                                 <span ng-if="match == '0'">NO</span>
                                 <span ng-if="match == null"></span>
+                                <span ng-if="match == '-1'" class="cancel-color">Automated Vote System Failure. Please report this issue via the "Request Help" link</span>
                             </div>
                         </div>
                         <div class="row">

--- a/src/app/review-results/final-access-review-results.controller.js
+++ b/src/app/review-results/final-access-review-results.controller.js
@@ -415,7 +415,11 @@
 
         function vaultVote(consentId) {
             cmMatchService.findMatch(consentId, $scope.electionAccess.referenceId).then(function (data) {
-                if (data.match !== null && data.match !== undefined) {
+                if (data.failed !== null && data.failed !== undefined && data.failed) {
+                    $scope.hideMatch = false;
+                    $scope.match = "-1";
+                    $scope.createDate = data.createDate;
+                } else if (data.match !== null && data.match !== undefined) {
                     $scope.hideMatch = false;
                     $scope.match = data.match;
                     $scope.createDate = data.createDate;

--- a/src/app/review-results/final-access-review-results.html
+++ b/src/app/review-results/final-access-review-results.html
@@ -143,7 +143,7 @@
                             <span class="access-color" ng-if="match == '1'"><b>YES</b></span>
                             <span class="access-color" ng-if="match == '0'"><b>NO</b></span>
                             <span class="access-color" ng-if="match == null"><b>---</b></span>
-                            <span class="cancel-color"" ng-if="match == '-1'">Automated Vote System Failure. Please report this issue via the "Request Help" link</span>
+                            <span class="cancel-color" ng-if="match == '-1'">Automated Vote System Failure. Please report this issue via the "Request Help" link</span>
                         </div>
                         <div ng-show="alertOn == true;" class="votes-alerts final-alert no-margin no-padding">
                             <alert ng-repeat="alert in alertsAgree" type="danger"
@@ -231,7 +231,7 @@
                                 <span ng-if="match == '1'">YES</span>
                                 <span ng-if="match == '0'">NO</span>
                                 <span ng-if="match == null"></span>
-                                <span ng-if="match == '-1'">Automated Vote System Failure. Please report this issue via the "Request Help" link</span>
+                                <span class="cancel-color" ng-if="match == '-1'">Automated Vote System Failure. Please report this issue via the "Request Help" link</span>
                             </div>
                         </div>
                         <div class="row">

--- a/src/app/review-results/final-access-review-results.html
+++ b/src/app/review-results/final-access-review-results.html
@@ -143,6 +143,7 @@
                             <span class="access-color" ng-if="match == '1'"><b>YES</b></span>
                             <span class="access-color" ng-if="match == '0'"><b>NO</b></span>
                             <span class="access-color" ng-if="match == null"><b>---</b></span>
+                            <span class="cancel-color"" ng-if="match == '-1'">Automated Vote System Failure. Please report this issue via the "Request Help" link</span>
                         </div>
                         <div ng-show="alertOn == true;" class="votes-alerts final-alert no-margin no-padding">
                             <alert ng-repeat="alert in alertsAgree" type="danger"
@@ -230,6 +231,7 @@
                                 <span ng-if="match == '1'">YES</span>
                                 <span ng-if="match == '0'">NO</span>
                                 <span ng-if="match == null"></span>
+                                <span ng-if="match == '-1'">Automated Vote System Failure. Please report this issue via the "Request Help" link</span>
                             </div>
                         </div>
                         <div class="row">


### PR DESCRIPTION
## Addresses:
Needed for, but does not complete https://broadinstitute.atlassian.net/browse/GAWB-3291
Requires https://github.com/DataBiosphere/consent/pull/260 to complete the story

## See Also:
Consent PR, https://github.com/DataBiosphere/consent/pull/260, that covers timeout exceptions. The two can proceed separately - they are related but not dependent.

## Changes
* Added conditional for the error case and display a corresponding error message in the UI.

### `access-results-record.html`
![error_message](https://user-images.githubusercontent.com/116679/38113501-30c08a44-3373-11e8-9985-f617c9b5edba.png)

### `final-access-review-results.html`
![screen shot 2018-03-30 at 11 35 59 am](https://user-images.githubusercontent.com/116679/38143512-d212306e-340e-11e8-8cd8-4af29dd0c89c.png)

## TODO
* I need PO approval on the language and format of the error message. 

## Testing
The  `access-results-record.html` path can be seen when running locally by going to "Manage Data Access Request" -> "Review" for `DAR-27` on dev.

The `final-access-review-results.html` path can be seen only as a chairperson. From the chairperson console, look for a "FINAL VOTE" button next to an election that has been completed by the chairperson. The "Vault Vote" section on that page mirrors the `access-results-record.html` case. Look for `DAR-0` for an example of one with an error message.

It takes a good amount of finagling to get a consent-purpose match into this state. What I did was set up a local consent server modified to throw a `SocketTimeoutException` for any single match case. Then, use the local swagger to call `PUT` on the same consent so it updates itself and tries to process matches. That generates a failure case that can then be seen in the `"Manage Data Access Request" -> "Review"` workflow described above. To see the chairperson-specific view, one has to log in as different DAC members and vote, then log in as the chairperson and collect votes on the election. After the final vote is collected, the "FINAL VOTE" button becomes visible, i.e. after the election has been finalized. 

