### PR TITLE
BTRX-205-212  Add Election Number and Archived reviewed elections, and BTRX-214 Search for combined fields

### DIFF
--- a/src/app/components/consent/consent.service.js
+++ b/src/app/components/consent/consent.service.js
@@ -27,6 +27,14 @@
             ConsentManageResource.List().$promise.then(
                 function (data) {
                     vm.electionsList.dul = data;
+
+                    var regex = new RegExp('-', 'g');
+                    vm.electionsList.dul.forEach(function(election) {
+                        var str = election.consentName;
+                        str = str.replace(regex, ' ');
+                        election.ct = election.consentName + ' ' + election.version;
+                        election.cts = str + ' ' + election.version;
+                    });
                 });
         }
 

--- a/src/app/components/session/session.service.js
+++ b/src/app/components/session/session.service.js
@@ -94,11 +94,11 @@
             if(!Boolean(roles)) {
                 visible =false;
             } else if (cmAuthenticateService.isAuthorized(rootRoles.admin, roles)) {
-                visible = true
+                visible = true;
             }  else {
                 var rolesNotAllowed = [rootRoles.researcher, rootRoles.dataOwner];
                 visible = roles.filter(function(role){
-                    return rolesNotAllowed.indexOf(role.name) !== -1}
+                    return rolesNotAllowed.indexOf(role.name) !== -1;}
                 ).length === 0;
             }
             return visible;

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -271,7 +271,7 @@ small {
     color:#2899BC;
     padding: 0;
     margin-bottom: 8px;
-    }
+}
 
 /**/
 
@@ -991,6 +991,21 @@ small {
     font-weight: 500;
 }
 
+.cell-sort:hover {
+    cursor: pointer;
+}
+
+.cell-sort:hover .sort-icon {
+    color: #2FA4E7;
+}
+
+.cell-sort .sort-icon {
+    color: #777777;
+    font-size: 10px;
+    margin-left: 5px;
+    vertical-align: 20%;
+}
+
 .cell-body {
     color: #777777;
     white-space: nowrap;
@@ -1700,21 +1715,21 @@ a .urgent:hover, a .pending:hover, a .editable:hover, a .enabled:hover {
     cursor: pointer !important;
 }
 
- .apply-dataset{
+.apply-dataset{
     margin-top: 25px;
 }
 
- .apply-dataset.disabled,
- .apply-dataset.disabled:hover{
+.apply-dataset.disabled,
+.apply-dataset.disabled:hover{
     background: #eeeeee !important;
     color: #cccccc !important;
     border: none !important;
     padding: 10px 15px 7px 15px !important;
 }
 
- .apply-dataset.disabled:hover{
+.apply-dataset.disabled:hover{
     cursor: default !important;
- }
+}
 
 .multi-step-pager li button{
     padding: 8px 15px 7px 15px !important;
@@ -3557,12 +3572,12 @@ tags-input .tags .tag-item{
     padding: 0 10px !important;
 }
 
-/***************************************************8 col grid*/
+/***************************************************7 col grid*/
 
 .grid-row {
     display: inline-block;
     width: 100%;
-    margin: 0; 
+    margin: 0;
     padding: 0;
 }
 

--- a/src/app/reviewed-cases/reviewed-cases.controller.js
+++ b/src/app/reviewed-cases/reviewed-cases.controller.js
@@ -9,30 +9,35 @@
 
         var vm = this;
         vm.electionsList = {'dul': [], 'access': []};
-        
+
         if($stateParams.menu !== true && $rootScope.currentDulPage !== undefined){
              $scope.currentDulPage = $rootScope.currentDulPage;
              $rootScope.currentDulPage = 1;
         } else{
             $rootScope.currentDulPage = 1;
-            $scope.currentDulPage = $rootScope.currentDulPage; 
+            $scope.currentDulPage = $rootScope.currentDulPage;
         }
-        
+
         $scope.$watch('currentDulPage', function(num) {
             $rootScope.currentDulPage = num;
         });
-        
+
         if($stateParams.menu !== true && $rootScope.currentDarPage !== undefined){
              $scope.currentDarPage = $rootScope.currentDarPage;
              $rootScope.currentDarPage = 1;
         } else{
             $rootScope.currentDarPage = 1;
-            $scope.currentDarPage = $rootScope.currentDarPage; 
+            $scope.currentDarPage = $rootScope.currentDarPage;
         }
-        
+
         $scope.$watch('currentDarPage', function(num) {
             $rootScope.currentDarPage = num;
         });
+
+        $scope.sort = function(keyname){
+            $scope.sortBy = keyname;
+            $scope.reverse = !$scope.reverse;
+        };
 
         init();
 
@@ -40,6 +45,13 @@
             vm.electionsList.dul = transformElectionResultData(reviewedConsents);
             vm.electionsList.access = transformElectionResultData(reviewedDRs);
 
+            var regex = new RegExp('-', 'g');
+            vm.electionsList.dul.forEach(function(election) {
+                var str = election.displayId;
+                str = str.replace(regex, ' ');
+                election.ct = String(election.displayId) + ' ' + String(election.version < 10 ? '0' + election.version : election.version);
+                election.cts = str + ' ' + String(election.version < 10 ? '0' + election.version : election.version);
+            });
         }
     }
 

--- a/src/app/reviewed-cases/reviewed-cases.html
+++ b/src/app/reviewed-cases/reviewed-cases.html
@@ -22,38 +22,39 @@
             </div>
         </div>
         <div class="jumbotron box-vote-singleresults box-vote-no-margin">
-            <div class="row">
-                <div class="pvotes-box-head row fsi-row-lg-level fsi-row-md-level">
-                    <div class="col-lg-4 col-md-4 col-sm-4 col-xs-4 pvotes-box-subtitle dul-color">Consent id</div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 pvotes-box-subtitle dul-color">Result Date</div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 center-text pvotes-box-subtitle dul-color">Final Result</div>
-                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 center-text pvotes-box-subtitle dul-color">Record</div>
-                    <hr class="pvotes-main-separator">
+            <div class="grid-row">
+                <div class="col-3 cell-header cell-sort dul-color" ng-click="sort('displayId')">Consent id
+                    <span class="glyphicon sort-icon glyphicon-sort"></span>
                 </div>
-                <div class="pvotes-box-body">
-                    <div dir-paginate="election in ReviewedCases.electionsList.dul | filter: searchDULcases | itemsPerPage:5" pagination-id="dulCases" current-page="currentDulPage">
-                        <hr class="pvotes-separator">
-                        <div class="row pvotes-main-list reviewed-cases-list">
-                            <div class="col-lg-4 col-md-4 col-sm-4 col-xs-4 pvotes-list-id">{{election.displayId}}</div>
-                            <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 pvotes-list-id">{{election.finalVoteDate}}</div>
-                            <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 pvotes-list-id center-text bold">
-                                <span ng-if="election.finalVoteString == 'Yes'" class="dul-color">YES</span>
-                                <span ng-if="election.finalVoteString == 'No'">NO</span>
-                            </div>
-                            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 btn-record">
-                                <a ui-sref="dul_results_record({electionId: '{{election.electionId}}'})">Record</a>
-                            </div>
-                        </div>
+                <div class="col-1 cell-header cell-sort dul-color" ng-click="sort('version')">Election N°
+                    <span class="glyphicon sort-icon glyphicon-sort"></span>
+                </div>
+                <div class="col-1 cell-header dul-color">Result Date</div>
+                <div class="col-1 cell-header f-center dul-color">Final Result</div>
+                <div class="col-1 cell-header f-center dul-color">Record</div>
+            </div>
+            <hr class="pvotes-main-separator">
+            <div dir-paginate="election in ReviewedCases.electionsList.dul | orderBy:sortBy:reverse | filter: searchDULcases | itemsPerPage:5" pagination-id="dulCases" current-page="currentDulPage">
+                <div class="grid-row">
+                    <div class="col-3 cell-body text" ng-class="{flagged : election.archived}">{{election.displayId}}</div>
+                    <div class="col-1 cell-body text">{{election.version < 10 ? '0' + election.version : election.version}}</div>
+                    <div class="col-1 cell-body text">{{election.finalVoteDate}}</div>
+                    <div class="col-1 cell-body text f-center bold">
+                        <span ng-if="election.finalVoteString == 'Yes'" class="dul-color">YES</span>
+                        <span ng-if="election.finalVoteString == 'No'">NO</span>
                     </div>
-                    <hr class="pvotes-separator">
+                    <div class="col-1 cell-body f-center">
+                        <button class="cell-button hover-color" ui-sref="dul_results_record({electionId: '{{election.electionId}}'})">Record</button>
+                    </div>
                 </div>
-                <div dir-pagination-controls
-                     max-size="5"
-                     direction-links="true"
-                     boundary-links="true"
-                     class="pvotes-pagination"
-                     pagination-id="dulCases">
-                </div>
+                <hr class="pvotes-separator">
+            </div>
+            <div dir-pagination-controls
+                 max-size="5"
+                 direction-links="true"
+                 boundary-links="true"
+                 class="pvotes-pagination"
+                 pagination-id="dulCases">
             </div>
         </div>
     </div>
@@ -72,39 +73,33 @@
             </div>
         </div>
         <div class="jumbotron box-vote-singleresults box-vote-no-margin">
-            <div class="row">
-                <div class="pvotes-box-head row fsi-row-lg-level fsi-row-md-level">
-                    <div class="col-lg-4 col-md-4 col-sm-4 col-xs-4 pvotes-box-subtitle access-color">Data Request Id</div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 pvotes-box-subtitle access-color">Result Date</div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 center-text pvotes-box-subtitle access-color">Final Result</div>
-                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 center-text pvotes-box-subtitle access-color">Record
+            <div class="grid-row">
+                <div class="col-4 cell-header access-color">Data Request id</div>
+                <div class="col-1 cell-header access-color">Result Date</div>
+                <div class="col-1 cell-header f-center access-color">Final Result</div>
+                <div class="col-1 cell-header f-center access-color">Record</div>
+            </div>
+            <hr class="pvotes-main-separator">
+            <div dir-paginate="election in ReviewedCases.electionsList.access | filter: searchAccessCases | itemsPerPage:5" pagination-id="accessCases" current-page="currentDarPage">
+                <div class="grid-row">
+                    <div class="col-4 cell-body text">{{election.displayId}}</div>
+                    <div class="col-1 cell-body text">{{election.finalVoteDate}}</div>
+                    <div class="col-1 cell-body text f-center bold">
+                        <span ng-if="election.finalVote == true" class="access-color">YES</span>
+                        <span ng-if="election.finalVote == false">NO</span>
                     </div>
-                    <hr class="pvotes-main-separator">
-                </div>
-                <div class="pvotes-box-body" id="searchTextResults">
-                    <div dir-paginate="election in ReviewedCases.electionsList.access | filter: searchAccessCases | itemsPerPage:5" pagination-id="accessCases" current-page="currentDarPage">
-                        <hr class="pvotes-separator">
-                        <div class="row pvotes-main-list admin-users-list">
-                            <div class="col-lg-4 col-md-4 col-sm-4 col-xs-4 pvotes-list-id">{{election.displayId}}</div>
-                            <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 pvotes-list-id">{{election.finalVoteDate}}</div>
-                            <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 pvotes-list-id center-text bold">
-                                <span ng-if="election.finalVote == true" class="access-color">YES</span>
-                                <span ng-if="election.finalVote == false">NO</span>
-                            </div>
-                            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 btn-edit">
-                                <a ui-sref="access_results_record({electionId: '{{election.electionId}}', referenceId: '{{election.referenceId}}'})">Record</a>
-                            </div>
-                        </div>
+                    <div class="col-1 cell-body f-center">
+                        <button class="cell-button hover-color" ui-sref="access_results_record({electionId: '{{election.electionId}}', referenceId: '{{election.referenceId}}'})">Record</button>
                     </div>
-                    <hr class="pvotes-separator">
                 </div>
-                <div dir-pagination-controls
-                     max-size="5"
-                     direction-links="true"
-                     boundary-links="true"
-                     class="pvotes-pagination"
-                     pagination-id="accessCases">
-                </div>
+                <hr class="pvotes-separator">
+            </div>
+            <div dir-pagination-controls
+                 max-size="5"
+                 direction-links="true"
+                 boundary-links="true"
+                 class="pvotes-pagination"
+                 pagination-id="accessCases">
             </div>
         </div>
     </div>


### PR DESCRIPTION
**BTRX-205-212**  
In Reviewed Cases Records page, as an admin I’d like to be able to:

    - see the Election Number
    - sort for Consent id and for Election Number
    - see every reviewed election related to any consent id (name)
    - easily notice which elections has been archived

**BTRX-214**
As an admin, I'd like to be able to search in Manage DUL and Reviewed Cases Record page, for a combination of Consent id (name) and Election Number fields. 
If possible, make this search work with either hyphen or space separated values.