### PR TITLE
BTRX-216 and BTRX-222 - Add Project Title on DAR related pages 

### DIFF
--- a/src/app/chair-console/chair-console.html
+++ b/src/app/chair-console/chair-console.html
@@ -100,7 +100,7 @@
                     <div dir-paginate="pendingCase in ChairConsole.electionsList.access | filter: searchAccessCases | itemsPerPage:5" pagination-id="accessCases">
                         <hr class="pvotes-separator">
                         <div class="row pvotes-main-list">
-                            <div class="col-lg-6 col-md-6 col-sm-6 col-xs-4 pvotes-list-id">{{pendingCase.frontEndId}} --  -- Title:  {{pendingCase.projectTitle}}</div>
+                            <div class="col-lg-6 col-md-6 col-sm-6 col-xs-4 pvotes-list-id">{{pendingCase.frontEndId}}</div>
                             <a ui-sref="access_review({darId: '{{pendingCase.referenceId}}', voteId: '{{pendingCase.voteId}}', rpVoteId:'{{pendingCase.rpVoteId}}'})" class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                                 <div class="voteButton {{pendingCase.alreadyVoted ? 'editable' : 'enabled'}}" ng-show="pendingCase.electionStatus !== 'Final'" >
                                     <span ng-if="pendingCase.alreadyVoted == false && pendingCase.electionStatus !== 'Final'">Vote</span>

--- a/src/app/chair-console/chair-console.html
+++ b/src/app/chair-console/chair-console.html
@@ -100,7 +100,7 @@
                     <div dir-paginate="pendingCase in ChairConsole.electionsList.access | filter: searchAccessCases | itemsPerPage:5" pagination-id="accessCases">
                         <hr class="pvotes-separator">
                         <div class="row pvotes-main-list">
-                            <div class="col-lg-6 col-md-6 col-sm-6 col-xs-4 pvotes-list-id">{{pendingCase.frontEndId}}</div>
+                            <div class="col-lg-6 col-md-6 col-sm-6 col-xs-4 pvotes-list-id">{{pendingCase.frontEndId}} --  -- Title:  {{pendingCase.projectTitle}}</div>
                             <a ui-sref="access_review({darId: '{{pendingCase.referenceId}}', voteId: '{{pendingCase.voteId}}', rpVoteId:'{{pendingCase.rpVoteId}}'})" class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                                 <div class="voteButton {{pendingCase.alreadyVoted ? 'editable' : 'enabled'}}" ng-show="pendingCase.electionStatus !== 'Final'" >
                                     <span ng-if="pendingCase.alreadyVoted == false && pendingCase.electionStatus !== 'Final'">Vote</span>

--- a/src/app/chair-console/chair-console.html
+++ b/src/app/chair-console/chair-console.html
@@ -83,15 +83,15 @@
         <div class="jumbotron box-vote-singleresults box-vote-no-margin">
             <div class="row">
                 <div class="pvotes-box-head  fsi-row-lg-level fsi-row-md-level">
-                    <div class="col-lg-6 col-md-6 col-sm-6 col-xs-4 pvotes-box-subtitle access-color">Data Request Id
-                    </div>
+                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 pvotes-box-subtitle access-color">Data Request Id</div>
+                    <div class="col-lg-4 col-md-4 col-sm-4 col-xs-3 pvotes-box-subtitle access-color">Project Title</div>
                     <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 center-text pvotes-box-subtitle access-color">Review/Vote
                         <div ng-show="ChairConsole.totalAccessPendingVotes > 0" id="accessPendingVoteCases" class="pcases-small-tag">{{ChairConsole.totalAccessPendingVotes}}</div>
                     </div>
-                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 center-text pvotes-box-subtitle access-color">
+                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 center-text pvotes-box-subtitle access-color">
                         Logged
                     </div>
-                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 center-text pvotes-box-subtitle access-color">
+                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 center-text pvotes-box-subtitle access-color">
                         Actions
                     </div>
                     <hr class="pvotes-main-separator">
@@ -100,15 +100,15 @@
                     <div dir-paginate="pendingCase in ChairConsole.electionsList.access | filter: searchAccessCases | itemsPerPage:5" pagination-id="accessCases">
                         <hr class="pvotes-separator">
                         <div class="row pvotes-main-list">
-                            <div class="col-lg-6 col-md-6 col-sm-6 col-xs-4 pvotes-list-id">{{pendingCase.frontEndId}}</div>
+                            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 pvotes-list-id" title="{{pendingCase.frontEndId}}">{{pendingCase.frontEndId}}</div>
+                            <div class="col-lg-4 col-md-4 col-sm-4 col-xs-3 pvotes-list-id" title="{{pendingCase.projectTitle}}">{{pendingCase.projectTitle}}</div>
                             <a ui-sref="access_review({darId: '{{pendingCase.referenceId}}', voteId: '{{pendingCase.voteId}}', rpVoteId:'{{pendingCase.rpVoteId}}'})" class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                                 <div class="voteButton {{pendingCase.alreadyVoted ? 'editable' : 'enabled'}}" ng-show="pendingCase.electionStatus !== 'Final'" >
                                     <span ng-if="pendingCase.alreadyVoted == false && pendingCase.electionStatus !== 'Final'">Vote</span>
                                     <span ng-if="pendingCase.alreadyVoted == true">Edit</span>
                                 </div>
                             </a>
-
-                            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 pvotes-list">{{pendingCase.logged}}</div>
+                            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 pvotes-list">{{pendingCase.logged}}</div>
                             <div ng-if="!pendingCase.alreadyVoted && pendingCase.electionStatus !== 'Final'">
                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 no-padding collectButton {{pendingCase.alreadyVoted ? 'enabled' : 'disabled' }}">
                                     <span>---</span>
@@ -116,7 +116,7 @@
                                 </a>
                             </div>
                             <div ng-if="pendingCase.alreadyVoted && !pendingCase.isFinalVote && pendingCase.electionStatus !== 'Final' ">
-                                <a ui-sref="access_review_results({referenceId: '{{pendingCase.referenceId}}' , electionId: '{{pendingCase.electionId}}'})" class="col-lg-2 col-md-2 col-sm-2 col-xs-3 no-padding">
+                                <a ui-sref="access_review_results({referenceId: '{{pendingCase.referenceId}}' , electionId: '{{pendingCase.electionId}}'})" class="col-lg-2 col-md-2 col-sm-2 col-xs-2 no-padding">
                                     <div class="collectButton {{pendingCase.alreadyVoted ? 'enabled' : 'disabled'}}">
                                         <span>Collect Votes</span>
                                     </div>

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -3580,7 +3580,7 @@ tags-input .tags .tag-item{
     padding: 0 10px !important;
 }
 
-/***************************************************7 col grid*/
+/***************************************************8 col grid*/
 
 .grid-row {
     display: inline-block;
@@ -3594,36 +3594,40 @@ tags-input .tags .tag-item{
     position: relative;
 }
 
-.grid-row .col-1, .grid-row .col-2, .grid-row .col-3, .grid-row .col-4, .grid-row .col-5, .grid-row .col-6, .grid-row .col-7{
+.grid-row .col-1, .grid-row .col-2, .grid-row .col-3, .grid-row .col-4, .grid-row .col-5, .grid-row .col-6, .grid-row .col-7, .grid-row .col-8{
     position: relative;
     min-height: 1px;
     float: left;
 }
 
 .grid-row .col-1 {
-    width: 14.285%;
+    width: 12.5%;
 }
 
 .grid-row .col-2 {
-    width: 28.57%;
+    width: 25%;
 }
 
 .grid-row .col-3 {
-    width: 42.855%;
+    width: 37.5%;
 }
 
 .grid-row .col-4 {
-    width: 57.14%;
+    width: 50%;
 }
 
 .grid-row .col-5 {
-    width: 71.425%;
+    width: 62.5%;
 }
 
 .grid-row .col-6 {
-    width: 85.71%;
+    width: 75%;
 }
 
 .grid-row .col-7 {
+    width: 87.5%;
+}
+
+.grid-row .col-8 {
     width: 100%;
 }

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -610,6 +610,14 @@ small {
     padding: 5px 0 0 3px;
 }
 
+.main-title-case{
+    font-size: 22px;
+    margin: 12px 0 0 2px;
+    display: block;
+    color: #333333;
+    font-weight: 300;
+}
+
 .cm-title, .cm-title-admin, .cm-subtitle, .cm-subtitle-ultimate, .cm-user-name, .cm-results-subtitle, .cm-box-title {
     color: #777777;
 }

--- a/src/app/results-record/access-results-record.controller.js
+++ b/src/app/results-record/access-results-record.controller.js
@@ -195,6 +195,9 @@
             cmRPService.getDarFields(electionReview.election.referenceId, "dar_code").then(function (data) {
                 $scope.darCode = data.dar_code;
             });
+            cmRPService.getDarFields(electionReview.election.referenceId, "projectTitle").then(function (data) {
+                $scope.projectTitle = data.projectTitle;
+            });
             $scope.electionAccess = electionReview.election;
             if (electionReview.election.finalRationale === null) {
                 $scope.electionAccess.finalRationale = '';

--- a/src/app/results-record/access-results-record.html
+++ b/src/app/results-record/access-results-record.html
@@ -3,10 +3,11 @@
     <div class="row fsi-row-lg-level fsi-row-md-level title-wrapper">
         <img src="assets/images/icon_access.png" alt="Data Access Request icon" class="cm-icons main-icon-title">
         <h2 class="main-title margin-sm access-color">
-            Data Access - Results Record | {{darCode}}<br>
-            <div class="main-title-description">Was the researcher allowed to access this research study?</div>
+            Data Access - Results Record<br>
+            <span class="main-title-case"><b>{{projectTitle}}</b> | {{darCode}}</span>
         </h2>
     </div>
+    <h3 class="access-color" style="font-style: italic;">Was the researcher allowed to access this research study?</h3>
     <div class="row fsi-row-lg-level fsi-row-md-level no-margin">
         <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes">
             <div class="panel-heading cm-boxhead access-color">

--- a/src/app/results-record/access-results-record.html
+++ b/src/app/results-record/access-results-record.html
@@ -3,7 +3,7 @@
     <div class="row fsi-row-lg-level fsi-row-md-level title-wrapper">
         <img src="assets/images/icon_access.png" alt="Data Access Request icon" class="cm-icons main-icon-title">
         <h2 class="main-title margin-sm access-color">
-            Data Access - Results Record<br>
+            Data Access - Results Record
             <span class="main-title-case"><b>{{projectTitle}}</b> | {{darCode}}</span>
         </h2>
     </div>

--- a/src/app/review-results/access-preview-results.controller.js
+++ b/src/app/review-results/access-preview-results.controller.js
@@ -8,6 +8,7 @@
 
         $scope.hasAdminRole = $rootScope.hasRole($rootScope.userRoles.admin);
         $scope.dar = dar;
+        $scope.request = request;
         $scope.rus = dar.rus;
         $scope.dar_id = dar_id;
         $scope.consent = consent;

--- a/src/app/review-results/access-preview-results.controller.js
+++ b/src/app/review-results/access-preview-results.controller.js
@@ -4,7 +4,7 @@
     angular.module('cmReviewResults')
         .controller('AccessPreviewResults', AccessPreviewResults);
 
-    function AccessPreviewResults($sce, $scope, $rootScope, $modal, $state, cmElectionService, cmLoginUserService, dar, rp, dar_id, consent, apiUrl, cmRPService, cmFilesService) {
+    function AccessPreviewResults($sce, $scope, $rootScope, $modal, $state, cmElectionService, cmLoginUserService, dar, rp, dar_id, consent, apiUrl, cmRPService, cmFilesService, dar_title) {
 
         $scope.hasAdminRole = $rootScope.hasRole($rootScope.userRoles.admin);
         $scope.dar = dar;

--- a/src/app/review-results/access-preview-results.controller.js
+++ b/src/app/review-results/access-preview-results.controller.js
@@ -4,7 +4,7 @@
     angular.module('cmReviewResults')
         .controller('AccessPreviewResults', AccessPreviewResults);
 
-    function AccessPreviewResults($sce, $scope, $rootScope, $modal, $state, cmElectionService, cmLoginUserService, dar, rp, dar_id, consent, apiUrl, cmRPService, cmFilesService, dar_title) {
+    function AccessPreviewResults($sce, $scope, $rootScope, $modal, $state, cmElectionService, cmLoginUserService, dar, rp, dar_id, consent, apiUrl, cmRPService, cmFilesService, request) {
 
         $scope.hasAdminRole = $rootScope.hasRole($rootScope.userRoles.admin);
         $scope.dar = dar;

--- a/src/app/review-results/access-preview-results.html
+++ b/src/app/review-results/access-preview-results.html
@@ -3,7 +3,8 @@
     <div class="row fsi-row-lg-level fsi-row-md-level title-wrapper">
         <img src="assets/images/icon_access.png" alt="Data Access Request icon" class="cm-icons main-icon-title">
         <h2 class="main-title margin-sm access-color">
-            Data Access Congruence Preview | {{consentName}}
+            Data Access Congruence Preview
+            <span class="main-title-case"><b>{{request.projectTitle}}</b> | {{consentName}}</span>
         </h2>
     </div>
     <accordion close-others="false">

--- a/src/app/review-results/access-review-results.controller.js
+++ b/src/app/review-results/access-review-results.controller.js
@@ -53,6 +53,7 @@
         $scope.downloadUrl = apiUrl + 'consent/' + electionReview.consent.consentId + '/dul';
         $scope.dulName = electionReview.consent.dulName;
         $scope.dar = dar.rus;
+        $scope.request = request;
         $scope.status = electionReview.election.status;
         $scope.isFormDisabled = $scope.chartData.accessChart[3][1] > 0;
         /*ALERTS*/

--- a/src/app/review-results/access-review-results.controller.js
+++ b/src/app/review-results/access-review-results.controller.js
@@ -4,7 +4,7 @@
     angular.module('cmReviewResults')
         .controller('AccessReviewResults', ReviewResults);
 
-    function ReviewResults($sce, $scope, $rootScope, $modal, $state, cmElectionService, cmLoginUserService, consent, electionReview, rpElectionReview, dar, apiUrl, cmEmailService, cmRPService, dar_id, cmFilesService) {
+    function ReviewResults($sce, $scope, $rootScope, $modal, $state, cmElectionService, cmLoginUserService, consent, electionReview, rpElectionReview, dar, apiUrl, cmEmailService, cmRPService, dar_id, cmFilesService, dar_title) {
 
         if(electionReview.election.status === "Canceled"){
             $state.go($state.go("access_review_not_found"));

--- a/src/app/review-results/access-review-results.controller.js
+++ b/src/app/review-results/access-review-results.controller.js
@@ -4,7 +4,7 @@
     angular.module('cmReviewResults')
         .controller('AccessReviewResults', ReviewResults);
 
-    function ReviewResults($sce, $scope, $rootScope, $modal, $state, cmElectionService, cmLoginUserService, consent, electionReview, rpElectionReview, dar, apiUrl, cmEmailService, cmRPService, dar_id, cmFilesService, dar_title) {
+    function ReviewResults($sce, $scope, $rootScope, $modal, $state, cmElectionService, cmLoginUserService, consent, electionReview, rpElectionReview, dar, apiUrl, cmEmailService, cmRPService, dar_id, cmFilesService, request) {
 
         if(electionReview.election.status === "Canceled"){
             $state.go($state.go("access_review_not_found"));

--- a/src/app/review-results/access-review-results.html
+++ b/src/app/review-results/access-review-results.html
@@ -3,7 +3,8 @@
     <div class="row fsi-row-lg-level fsi-row-md-level title-wrapper">
         <img src="assets/images/icon_access.png" alt="Data Access Request icon" class="cm-icons main-icon-title">
         <h2 class="main-title margin-sm access-color">
-            {{ hasAdminRole ? "" : "Collect"}} Votes for Data Access Congruence Review | {{consentName}}
+            {{ hasAdminRole ? "" : "Collect"}} Votes for Data Access Congruence Review
+            <span class="main-title-case"><b>{{request.projectTitle}}</b> | {{consentName}}</span>
         </h2>
     </div>
     <accordion>

--- a/src/app/review-results/final-access-review-results.controller.js
+++ b/src/app/review-results/final-access-review-results.controller.js
@@ -340,7 +340,7 @@
                 $scope.dar = data;
             });
             cmRPService.getDarFields(electionReview.election.referenceId, "projectTitle").then(function (data) {
-                $scope.dar_title = data.projectTitle;
+                $scope.projectTitle = data.projectTitle;
             });
             $scope.electionAccess = electionReview.election;
             if (electionReview.election.finalRationale === null) {

--- a/src/app/review-results/final-access-review-results.controller.js
+++ b/src/app/review-results/final-access-review-results.controller.js
@@ -339,6 +339,9 @@
             cmRPService.getDarFields(electionReview.election.referenceId, "rus").then(function (data) {
                 $scope.dar = data;
             });
+            cmRPService.getDarFields(electionReview.election.referenceId, "projectTitle").then(function (data) {
+                $scope.dar_title = data.projectTitle;
+            });
             $scope.electionAccess = electionReview.election;
             if (electionReview.election.finalRationale === null) {
                 $scope.electionAccess.finalRationale = '';

--- a/src/app/review-results/final-access-review-results.html
+++ b/src/app/review-results/final-access-review-results.html
@@ -2,7 +2,7 @@
 <div class="container">
     <div class="row fsi-row-lg-level fsi-row-md-level title-wrapper">
         <img src="assets/images/icon_access.png" alt="Data Access Request icon" class="cm-icons main-icon-title">
-        <h2 class="main-title margin-sm access-color">Final voting for Data Access Review<br>
+        <h2 class="main-title margin-sm access-color">Final voting for Data Access Review
             <span class="main-title-case"><b>{{projectTitle}}</b></span>
         </h2>
     </div>

--- a/src/app/review-results/final-access-review-results.html
+++ b/src/app/review-results/final-access-review-results.html
@@ -3,9 +3,10 @@
     <div class="row fsi-row-lg-level fsi-row-md-level title-wrapper">
         <img src="assets/images/icon_access.png" alt="Data Access Request icon" class="cm-icons main-icon-title">
         <h2 class="main-title margin-sm access-color">Final voting for Data Access Review<br>
-            <div class="main-title-description">Is the researcher going to be allowed to access this research study?</div>
+            <span class="main-title-case"><b>{{projectTitle}}</b></span>
         </h2>
     </div>
+    <h3 class="access-color" style="font-style: italic;">Is the researcher going to be allowed to access this research study?</h3>
     <div class="row fsi-row-lg-level fsi-row-md-level no-margin">
         <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes">
             <div class="panel-heading cm-boxhead access-color">

--- a/src/app/review-results/review-results.route.js
+++ b/src/app/review-results/review-results.route.js
@@ -70,7 +70,7 @@
                     dar_id: function ($stateParams) {
                             return $stateParams.referenceId;
                     },
-                    dar_title: function ($stateParams, cmRPService) {
+                    request: function ($stateParams, cmRPService) {
                         if ($stateParams.referenceId !== null) {
                             return cmRPService.getDarFields($stateParams.referenceId, "projectTitle");
                         }
@@ -137,7 +137,7 @@
                             return cmRPService.getDarConsent($stateParams.referenceId);
                         }
                     },
-                    dar_title: function ($stateParams, cmRPService) {
+                    request: function ($stateParams, cmRPService) {
                         if ($stateParams.referenceId !== null) {
                             return cmRPService.getDarFields($stateParams.referenceId, "projectTitle");
                         }

--- a/src/app/review-results/review-results.route.js
+++ b/src/app/review-results/review-results.route.js
@@ -69,7 +69,12 @@
                     },
                     dar_id: function ($stateParams) {
                             return $stateParams.referenceId;
-                    }
+                    },
+                    dar_title: function ($stateParams, cmRPService) {
+                        if ($stateParams.referenceId !== null) {
+                            return cmRPService.getDarFields($stateParams.referenceId, "projectTitle");
+                        }
+                    },
                 }
             })
 
@@ -130,6 +135,11 @@
                     consent: function ($stateParams, cmRPService) {
                         if ($stateParams.referenceId !== null) {
                             return cmRPService.getDarConsent($stateParams.referenceId);
+                        }
+                    },
+                    dar_title: function ($stateParams, cmRPService) {
+                        if ($stateParams.referenceId !== null) {
+                            return cmRPService.getDarFields($stateParams.referenceId, "projectTitle");
                         }
                     }
                 }

--- a/src/app/review/access-review.controller.js
+++ b/src/app/review/access-review.controller.js
@@ -82,7 +82,9 @@
         $scope.selection = {};
         $scope.downloadUrl = apiUrl + 'consent/' + consent.consentId + '/dul';
         $scope.consent = consent;
+        $scope.consentName = consent.name;
         $scope.dar = dar;
+        $scope.request = request;
         $scope.selection.voteStatus = vote.vote;
         $scope.isFormDisabled = (election.status === 'Closed');
         $scope.selection.rationale = vote.rationale;

--- a/src/app/review/access-review.controller.js
+++ b/src/app/review/access-review.controller.js
@@ -4,7 +4,7 @@
     angular.module('cmReview')
         .controller('DarReview', DarReview);
 
-    function DarReview($sce, $scope, $modal, $state, $rootScope, USER_ROLES, vote, rpVote, dar, election, consent, cmVoteService, apiUrl, cmAuthenticateService, cmLoginUserService, cmRPService, dar_id, cmFilesService, dar_title) {
+    function DarReview($sce, $scope, $modal, $state, $rootScope, USER_ROLES, vote, rpVote, dar, election, consent, cmVoteService, apiUrl, cmAuthenticateService, cmLoginUserService, cmRPService, dar_id, cmFilesService, request) {
 
         var vm = this;
         vm.openApplication = openApplication;

--- a/src/app/review/access-review.controller.js
+++ b/src/app/review/access-review.controller.js
@@ -4,7 +4,7 @@
     angular.module('cmReview')
         .controller('DarReview', DarReview);
 
-    function DarReview($sce, $scope, $modal, $state, $rootScope, USER_ROLES, vote, rpVote, dar, election, consent, cmVoteService, apiUrl, cmAuthenticateService, cmLoginUserService, cmRPService, dar_id, cmFilesService) {
+    function DarReview($sce, $scope, $modal, $state, $rootScope, USER_ROLES, vote, rpVote, dar, election, consent, cmVoteService, apiUrl, cmAuthenticateService, cmLoginUserService, cmRPService, dar_id, cmFilesService, dar_title) {
 
         var vm = this;
         vm.openApplication = openApplication;

--- a/src/app/review/access-review.html
+++ b/src/app/review/access-review.html
@@ -2,8 +2,8 @@
 <div class="container">
     <div class="row fsi-row-lg-level fsi-row-md-level title-wrapper">
         <img src="assets/images/icon_access.png" alt="Data Access Request icon" class="cm-icons main-icon-title">
-        <h2 class="main-title margin-sm access-color">
-            Data Access Congruence Review
+        <h2 class="main-title margin-sm access-color">Data Access Congruence Review
+            <span class="main-title-case"><b>{{request.projectTitle}}</b> | {{consentName}}</span>
         </h2>
     </div>
     <accordion>

--- a/src/app/review/review.route.js
+++ b/src/app/review/review.route.js
@@ -87,7 +87,7 @@
                     dar_id: function($stateParams){
                         return $stateParams.darId;
                     },
-                    dar_title: function ($stateParams, cmRPService) {
+                    request: function ($stateParams, cmRPService) {
                         if ($stateParams.darId !== null) {
                             return cmRPService.getDarFields($stateParams.darId, "projectTitle");
                         }

--- a/src/app/review/review.route.js
+++ b/src/app/review/review.route.js
@@ -86,6 +86,11 @@
                     },
                     dar_id: function($stateParams){
                         return $stateParams.darId;
+                    },
+                    dar_title: function ($stateParams, cmRPService) {
+                        if ($stateParams.darId !== null) {
+                            return cmRPService.getDarFields($stateParams.darId, "projectTitle");
+                        }
                     }
                 }
             });

--- a/src/app/reviewed-cases/reviewed-cases.html
+++ b/src/app/reviewed-cases/reviewed-cases.html
@@ -74,7 +74,8 @@
         </div>
         <div class="jumbotron box-vote-singleresults box-vote-no-margin">
             <div class="grid-row">
-                <div class="col-4 cell-header access-color">Data Request id</div>
+                <div class="col-2 cell-header access-color">Data Request id</div>
+                <div class="col-2 cell-header access-color">Project Title</div>
                 <div class="col-1 cell-header access-color">Result Date</div>
                 <div class="col-1 cell-header f-center access-color">Final Result</div>
                 <div class="col-1 cell-header f-center access-color">Record</div>
@@ -82,7 +83,8 @@
             <hr class="pvotes-main-separator">
             <div dir-paginate="election in ReviewedCases.electionsList.access | filter: searchAccessCases | itemsPerPage:5" pagination-id="accessCases" current-page="currentDarPage">
                 <div class="grid-row">
-                    <div class="col-4 cell-body text">{{election.displayId}}</div>
+                    <div class="col-2 cell-body text" title="{{election.displayId}}">{{election.displayId}}</div>
+                    <div class="col-2 cell-body text" title="{{election.projectTitle}}">{{election.projectTitle}}</div>
                     <div class="col-1 cell-body text">{{election.finalVoteDate}}</div>
                     <div class="col-1 cell-body text f-center bold">
                         <span ng-if="election.finalVote == true" class="access-color">YES</span>

--- a/src/app/reviewed-cases/reviewed-cases.html
+++ b/src/app/reviewed-cases/reviewed-cases.html
@@ -8,7 +8,7 @@
         </h2>
     </div>
     <hr class="section-separator">
-    <div class="col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12">
+    <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
         <div class="row">
             <h2 class="col-lg-8 col-md-8 col-sm-8 col-xs-12 pvotes-box-title dul-color">
                 <img src="assets/images/icon_dul.png" alt="DUL icon" class="pvotes-icons">Data Use Limitations Reviewed Cases
@@ -26,7 +26,7 @@
                 <div class="col-3 cell-header cell-sort dul-color" ng-click="sort('displayId')">Consent id
                     <span class="glyphicon sort-icon glyphicon-sort"></span>
                 </div>
-                <div class="col-1 cell-header cell-sort dul-color" ng-click="sort('version')">Election N°
+                <div class="col-2 cell-header cell-sort dul-color" ng-click="sort('version')">Election N°
                     <span class="glyphicon sort-icon glyphicon-sort"></span>
                 </div>
                 <div class="col-1 cell-header dul-color">Result Date</div>
@@ -37,7 +37,7 @@
             <div dir-paginate="election in ReviewedCases.electionsList.dul | orderBy:sortBy:reverse | filter: searchDULcases | itemsPerPage:5" pagination-id="dulCases" current-page="currentDulPage">
                 <div class="grid-row">
                     <div class="col-3 cell-body text" ng-class="{flagged : election.archived}">{{election.displayId}}</div>
-                    <div class="col-1 cell-body text">{{election.version < 10 ? '0' + election.version : election.version}}</div>
+                    <div class="col-2 cell-body text">{{election.version < 10 ? '0' + election.version : election.version}}</div>
                     <div class="col-1 cell-body text">{{election.finalVoteDate}}</div>
                     <div class="col-1 cell-body text f-center bold">
                         <span ng-if="election.finalVoteString == 'Yes'" class="dul-color">YES</span>
@@ -59,7 +59,7 @@
         </div>
     </div>
 
-    <div class="col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12">
+    <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
         <div class="row">
             <h2 class="col-lg-8 col-md-8 col-sm-8 col-xs-12 pvotes-box-title access-color">
                 <img src="assets/images/icon_access.png" alt="Access icon" class="pvotes-icons">Data Access Reviewed Cases
@@ -75,7 +75,7 @@
         <div class="jumbotron box-vote-singleresults box-vote-no-margin">
             <div class="grid-row">
                 <div class="col-2 cell-header access-color">Data Request id</div>
-                <div class="col-2 cell-header access-color">Project Title</div>
+                <div class="col-3 cell-header access-color">Project Title</div>
                 <div class="col-1 cell-header access-color">Result Date</div>
                 <div class="col-1 cell-header f-center access-color">Final Result</div>
                 <div class="col-1 cell-header f-center access-color">Record</div>
@@ -84,7 +84,7 @@
             <div dir-paginate="election in ReviewedCases.electionsList.access | filter: searchAccessCases | itemsPerPage:5" pagination-id="accessCases" current-page="currentDarPage">
                 <div class="grid-row">
                     <div class="col-2 cell-body text" title="{{election.displayId}}">{{election.displayId}}</div>
-                    <div class="col-2 cell-body text" title="{{election.projectTitle}}">{{election.projectTitle}}</div>
+                    <div class="col-3 cell-body text" title="{{election.projectTitle}}">{{election.projectTitle}}</div>
                     <div class="col-1 cell-body text">{{election.finalVoteDate}}</div>
                     <div class="col-1 cell-body text f-center bold">
                         <span ng-if="election.finalVote == true" class="access-color">YES</span>

--- a/src/app/user-console/user-console.html
+++ b/src/app/user-console/user-console.html
@@ -80,14 +80,10 @@
         <div class="jumbotron box-vote-singleresults box-vote-no-margin">
             <div class="row">
                 <div class="pvotes-box-head fsi-row-lg-level fsi-row-md-level">
-                    <div class="col-lg-6 col-md-6 col-sm-6 col-xs-4 pvotes-box-subtitle access-color">Data Request Id
-                    </div>
-                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 center-text pvotes-box-subtitle access-color">
-                        Status
-                    </div>
-                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 center-text pvotes-box-subtitle access-color">
-                        Logged
-                    </div>
+                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 pvotes-box-subtitle access-color">Data Request Id</div>
+                    <div class="col-lg-4 col-md-4 col-sm-4 col-xs-3 pvotes-box-subtitle access-color">Project Title</div>
+                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 center-text pvotes-box-subtitle access-color">Status</div>
+                    <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 center-text pvotes-box-subtitle access-color">Logged</div>
                     <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 center-text pvotes-box-subtitle access-color">Review/Vote
                         <div ng-show="UserConsole.totalAccessPendingVotes > 0" class="pcases-small-tag">{{UserConsole.totalAccessPendingVotes}}</div>
                     </div>
@@ -97,13 +93,14 @@
                     <div dir-paginate="pendingCase in UserConsole.electionsList.access | filter: searchAccessCases | itemsPerPage:5" pagination-id="accessCases">
                         <hr class="pvotes-separator">
                         <div class="row pvotes-main-list">
-                            <div class="col-lg-6 col-md-6 col-sm-6 col-xs-4 pvotes-list-id">{{pendingCase.frontEndId}}</div>
-                            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 pvotes-list {{pendingCase.status}}">
+                            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 pvotes-list-id" title="{{pendingCase.frontEndId}}">{{pendingCase.frontEndId}}</div>
+                            <div class="col-lg-4 col-md-4 col-sm-4 col-xs-3 pvotes-list-id" title="{{pendingCase.projectTitle}}">{{pendingCase.projectTitle}}</div>
+                            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 pvotes-list {{pendingCase.status}}">
                                 <span ng-if="pendingCase.isReminderSent == true">URGENT!</span>
                                 <span ng-if="pendingCase.status == 'pending' && pendingCase.isReminderSent != true">Pending</span>
                                 <span ng-if="pendingCase.status == 'editable'">Editable</span>
                             </div>
-                            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 pvotes-list">{{pendingCase.logged}}</div>
+                            <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 pvotes-list">{{pendingCase.logged}}</div>
                             <a ui-sref="access_review({darId: '{{pendingCase.referenceId}}', voteId: '{{pendingCase.voteId}}',rpVoteId:'{{pendingCase.rpVoteId}}'  })" class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                                 <div class="{{pendingCase.status}}">
                                     <span ng-if="pendingCase.alreadyVoted == false">Vote</span>


### PR DESCRIPTION
As a admin/member/chairperson I’d like to see the Request Application Project Title in the following pages: 
**Table layout pages:**
Member Console (user_console)
Chairperson Console (chair_console)
Reviewed Cases Record (reviewed_cases on DAR section).

**Election layout pages:**
DAR Congruence Review (access_review)
DAR Collect Votes (access_review_results)
DAR Final Access Decision (final_access_review_results)
DAR Preview Results (access_preview_results)
DAR Result Records (access_results_record)

In the Table layout pages, this new data field should be placed inside the table as a new column and in the Election cases layout it should be located in the same line as the main title of the page.

**Acceptance Criteria:** The Request Application Project Title appears next to the DAR ID in every table and page title or subtitle where the DAR ID currently appears.