### PR TITLE
BTRX - 226 - Show election related DUL and sDUL in every page

### DIFF
--- a/src/app/components/files/files.service.js
+++ b/src/app/components/files/files.service.js
@@ -6,9 +6,13 @@
 
     /* ngInject */
     function cmFilesService($http, apiUrl) {
-//
         function getDULFile(consentId, fileName) {
             var consentUrl = apiUrl + 'consent/' + consentId + '/dul';
+            getFile(consentUrl, fileName);
+        }
+
+        function getDulFileByElectionId(consentId, fileName, electionId) {
+            var consentUrl = apiUrl + 'consent/' + consentId + '/dul?electionId=' + electionId;
             getFile(consentUrl, fileName);
         }
 
@@ -49,6 +53,9 @@
         }
 
         return {
+            getDulFileByElectionId: function(consentId, fileName, electionId){
+                return getDulFileByElectionId(consentId, fileName, electionId);
+            },
             getDULFile: function (consentId, fileName) {
                 return getDULFile(consentId, fileName);
             },

--- a/src/app/components/files/files.service.js
+++ b/src/app/components/files/files.service.js
@@ -6,6 +6,7 @@
 
     /* ngInject */
     function cmFilesService($http, apiUrl) {
+
         function getDULFile(consentId, fileName) {
             var consentUrl = apiUrl + 'consent/' + consentId + '/dul';
             getFile(consentUrl, fileName);
@@ -36,7 +37,6 @@
                         var downloadElement = angular.element('<a/>');
                         downloadElement.css({ display: 'none' });
                         angular.element(document.body).append(downloadElement);
-
                         if (isIE) {
                             downloadElement.attr({
                                 href: window.navigator.msSaveOrOpenBlob(blob, fileName)

--- a/src/app/components/files/files.service.js
+++ b/src/app/components/files/files.service.js
@@ -6,7 +6,7 @@
 
     /* ngInject */
     function cmFilesService($http, apiUrl) {
-
+//
         function getDULFile(consentId, fileName) {
             var consentUrl = apiUrl + 'consent/' + consentId + '/dul';
             getFile(consentUrl, fileName);
@@ -32,7 +32,7 @@
                         var downloadElement = angular.element('<a/>');
                         downloadElement.css({ display: 'none' });
                         angular.element(document.body).append(downloadElement);
-                        
+
                         if (isIE) {
                             downloadElement.attr({
                                 href: window.navigator.msSaveOrOpenBlob(blob, fileName)

--- a/src/app/results-record/dul-results-record.controller.js
+++ b/src/app/results-record/dul-results-record.controller.js
@@ -69,9 +69,9 @@
         if (electionReview.election.finalRationale === 'null') {
             $scope.election.finalRationale = '';
         }
-        $scope.dul = electionReview.consent.dataUseLetter;
+        $scope.dul = electionReview.election.dataUseLetter;
         $scope.downloadUrl = apiUrl + 'consent/' + electionReview.consent.consentId + '/dul';
-        $scope.dulName = electionReview.consent.dulName;
+        $scope.dulName = electionReview.election.dulName;
         $scope.structuredDataUseLetter = $sce.trustAsHtml(electionReview.election.translatedUseRestriction);
 
         $scope.finalRationale = electionReview.election.finalRationale;

--- a/src/app/results-record/dul-results-record.controller.js
+++ b/src/app/results-record/dul-results-record.controller.js
@@ -81,7 +81,7 @@
         $scope.chartData = getGraphData(electionReview.reviewVote);
 
         $scope.downloadDUL = function(){
-            cmFilesService.getDULFile(electionReview.consent.consentId, electionReview.consent.dulName);
+            cmFilesService.getDulFileByElectionId(electionReview.consent.consentId, electionReview.election.dulName, electionReview.election.electionId);
         };
 
         function chunk(arr, size) {

--- a/src/app/review-results/dul-preview-results.controller.js
+++ b/src/app/review-results/dul-preview-results.controller.js
@@ -23,7 +23,6 @@
         $scope.downloadUrl = apiUrl + 'consent/' + $scope.consent.consentId + '/dul';
         $scope.dulName = dulName;
         $scope.dataUseLetter = $scope.consent.dataUseLetter;
-        // $scope.structuredDataUseLetter = $sce.trustAsHtml($scope.consent.translatedUseRestriction);
         $scope.downloadDUL = function(){
             cmFilesService.getDULFile($scope.consent.consentId, $scope.consent.dulName);
         };

--- a/src/app/review-results/dul-preview-results.controller.js
+++ b/src/app/review-results/dul-preview-results.controller.js
@@ -4,14 +4,26 @@
     angular.module('cmReviewResults')
         .controller('DulPreviewResults', DulPreviewResults);
 
-    function DulPreviewResults($sce, apiUrl, $scope, $rootScope, $modal, $state, consent, cmFilesService) {
+    function DulPreviewResults($sce, apiUrl, $scope, $rootScope, $modal, $state, consent, cmFilesService, electionReview) {
         $scope.hasAdminRole = $rootScope.hasRole($rootScope.userRoles.admin);
         $scope.consent = consent;
+        $scope.election = electionReview.election;
+        var dulName;
+        if (typeof electionReview.election === 'undefined'){
+            dulName = $scope.consent.dulName;
+            $scope.dataUseLetter = $scope.consent.dataUseLetter;
+            $scope.structuredDataUseLetter = $sce.trustAsHtml($scope.consent.translatedUseRestriction);
+
+        } else {
+            dulName = electionReview.election.dulName;
+            $scope.dataUseLetter = electionReview.election.dataUseLetter;
+            $scope.structuredDataUseLetter = $sce.trustAsHtml(electionReview.election.translatedUseRestriction);
+        }
         $scope.consentName = consent.name;
         $scope.downloadUrl = apiUrl + 'consent/' + $scope.consent.consentId + '/dul';
-        $scope.dulName = $scope.consent.dulName;
+        $scope.dulName = dulName;
         $scope.dataUseLetter = $scope.consent.dataUseLetter;
-        $scope.structuredDataUseLetter = $sce.trustAsHtml($scope.consent.translatedUseRestriction);
+        // $scope.structuredDataUseLetter = $sce.trustAsHtml($scope.consent.translatedUseRestriction);
         $scope.downloadDUL = function(){
             cmFilesService.getDULFile($scope.consent.consentId, $scope.consent.dulName);
         };

--- a/src/app/review-results/dul-review-results.controller.js
+++ b/src/app/review-results/dul-review-results.controller.js
@@ -67,9 +67,9 @@
             $scope.election.finalRationale = '';
         }
 
-        $scope.dul = electionReview.consent.dataUseLetter;
+        $scope.dul = electionReview.election.dataUseLetter;
         $scope.downloadUrl = apiUrl + 'consent/' + electionReview.consent.consentId + '/dul';
-        $scope.dulName = electionReview.consent.dulName;
+        $scope.dulName = electionReview.election.dulName;
         $scope.consentName = electionReview.consent.name;
         $scope.structuredDataUseLetter = $sce.trustAsHtml(electionReview.election.translatedUseRestriction);
         $scope.positiveVote = positiveVote;

--- a/src/app/review-results/final-access-review-results.controller.js
+++ b/src/app/review-results/final-access-review-results.controller.js
@@ -47,7 +47,7 @@
         init();
 
         $scope.downloadDUL = function(){
-            cmFilesService.getDULFile($scope.electionReview.consent.consentId, $scope.electionReview.consent.dulName);
+            cmFilesService.getDULFile($scope.electionReview.consent.consentId, $scope.electionReview.election.dulName);
         };
 
         function logVote() {
@@ -358,7 +358,7 @@
                 $scope.election.finalRationale = '';
             }
             $scope.downloadUrl = apiUrl + 'consent/' + electionReview.consent.consentId + '/dul';
-            $scope.dulName = electionReview.consent.dulName;
+            $scope.dulName = electionReview.election.dulName;
             $scope.status = electionReview.election.status;
             $scope.voteList = chunk(electionReview.reviewVote, 2);
             $scope.chartDataDUL = getGraphData(electionReview.reviewVote);

--- a/src/app/review-results/review-results.route.js
+++ b/src/app/review-results/review-results.route.js
@@ -148,6 +148,11 @@
                     authorizedRoles: [USER_ROLES.chairperson, USER_ROLES.admin]
                 },
                 resolve: {
+                    electionReview: function ($stateParams, cmElectionService) {
+                        if ($stateParams.consentId !== null) {
+                            return cmElectionService.findElectionReview($stateParams.consentId, 'TranslateDUL').$promise;
+                        }
+                    },
                     consent: function ($stateParams, cmConsentService) {
                         if ($stateParams.consentId !== null) {
                             return cmConsentService.findConsent($stateParams.consentId);

--- a/src/app/review/dul-review.controller.js
+++ b/src/app/review/dul-review.controller.js
@@ -12,8 +12,8 @@
             return;
         }
         $scope.downloadUrl = apiUrl + 'consent/' + consent.consentId + '/dul';
-        $scope.consentDulName = consent.dulName;
-        $scope.consentSDul = $sce.trustAsHtml(consent.translatedUseRestriction);
+        $scope.consentDulName = election.dulName;
+        $scope.consentSDul = $sce.trustAsHtml(election.translatedUseRestriction);
         $scope.voteStatus = vote.vote;
         $scope.isFormDisabled = (election.status === 'Closed');
         $scope.rationale = vote.rationale;
@@ -42,7 +42,7 @@
         };
 
         $scope.downloadDUL = function(){
-            cmFilesService.getDULFile(consent.consentId, consent.dulName);
+            cmFilesService.getDULFile(consent.consentId, election.dulName);
         };
 
         $scope.logVote = function () {


### PR DESCRIPTION
### Description

_- Changed the source used to display DUL names and translated DUL._

_- Added new method call, to get Dul by election Id._

_- Made election info available in `dul preview results controller.js`_

**Jira Story**
[BTRX-226-Show election related DUL and sDUL in every page](https://broadinstitute.atlassian.net/browse/BTRX-226)

**Note:** This code is related to the backend branch [lf-BTRX-226-electionDulandSdul](https://github.com/DataBiosphere/consent/tree/lf-BTRX-226-electionDulandSdul) in order to work properly.