### PR TITLE
BTRX-246 Improvements related to Consent Group Name display

### DIFF
--- a/src/app/admin-manage/admin-manage-dul.html
+++ b/src/app/admin-manage/admin-manage-dul.html
@@ -38,11 +38,8 @@
         <div dir-paginate="election in AdminManage.electionsList.dul | filter: searchDUL | itemsPerPage:10" current-page="AdminManage.currentDULPage">
             <div class="grid-9-row pushed-2">
                 <div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.consentName}}">{{election.consentName}}</div>
-                <div class="col-2 cell-body text" title="{{election.groupName}}">{{election.groupName}}</div>
-                <div class="col-1 cell-body text">
-                    <span ng-show="election.electionStatus == 'un-reviewed'">- -</span>
-                    <span ng-show="election.electionStatus != 'un-reviewed'">{{election.version}}</span>
-                </div>
+                <div class="col-2 cell-body text" ng-class="{empty : !election.groupName}" title="{{election.groupName}}">{{election.groupName}}</div>
+                <div class="col-1 cell-body text" ng-class="{empty : !election.version}">{{election.version}}</div>
                 <div class="col-1 cell-body text">{{election.createDate | date:'yyyy-MM-dd'}}</div>
                 <div class="col-1 cell-body f-center">
                     <button class="cell-button hover-color" ng-disabled="election.electionStatus != 'un-reviewed' || !election.editable" ng-click="AdminManage.editDul(election.consentId)">Edit</button>
@@ -54,7 +51,7 @@
                     <span ng-if="election.electionStatus == 'Closed'"><a ng-click="AdminManage.open(null, 'dul_results_record', election.electionId)">Reviewed</a></span>
                 </div>
                 <div class="col-1 cell-body f-center">
-                    <button ng-if="election.electionStatus != 'Open' && election.editable" ng-disabled="!election.editable" class="cell-button hover-color" ng-click="AdminManage.openCreate(election)">Create</button>
+                    <button ng-if="election.electionStatus != 'Open'" ng-disabled="!election.editable" class="cell-button hover-color" ng-click="AdminManage.openCreate(election)">Create</button>
                     <button ng-if="election.electionStatus == 'Open'" class="cell-button cancel-color" ng-click="AdminManage.openCancel(election)">Cancel</button>
                 </div>
                 <div class="icon-actions">

--- a/src/app/chair-console/chair-console.html
+++ b/src/app/chair-console/chair-console.html
@@ -39,7 +39,7 @@
                         <hr class="pvotes-separator">
                         <div class="row pvotes-main-list">
                             <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 pvotes-list-id" title="{{pendingCase.frontEndId}}">{{pendingCase.frontEndId}}</div>
-                            <div class="col-lg-4 col-md-4 col-sm-4 col-xs-3 pvotes-list-id" title="{{pendingCase.consentGroupName}}">{{pendingCase.consentGroupName}}</div>
+                            <div class="col-lg-4 col-md-4 col-sm-4 col-xs-3 pvotes-list-id" ng-class="{empty : !pendingCase.consentGroupName}" title="{{pendingCase.consentGroupName}}">{{pendingCase.consentGroupName}}</div>
                             <a ng-click="ChairConsole.openDULReview(pendingCase.referenceId, pendingCase.voteId)" class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                                 <div class="voteButton {{pendingCase.alreadyVoted ? 'editable' : 'enabled'}}">
                                     <span ng-if="pendingCase.alreadyVoted == false">Vote</span>

--- a/src/app/components/consent/consent.service.js
+++ b/src/app/components/consent/consent.service.js
@@ -5,7 +5,7 @@
         .service('cmConsentService', cmConsentService);
 
     /* ngInject */
-    function cmConsentService(ConsentInvalidRestriction, ConsentResource, DeleteConsentResource, ConsentDulResource, ConsentManageResource, CreateConsentResource, CreateDulResource, UpdateConsentResource) {
+    function cmConsentService(ConsentInvalidRestriction, ConsentResource, DeleteConsentResource, ConsentDulResource, ConsentManageResource, CreateConsentResource, CreateDulResource, UpdateConsentResource, $sce) {
 
         /**
          * Find data for the consent related to the consentId sent as a parameter
@@ -34,6 +34,7 @@
                         str = str.replace(regex, ' ');
                         election.ct = election.consentName + ' ' + election.version;
                         election.cts = str + ' ' + election.version;
+                        election.groupName = $sce.trustAsHtml(election.groupName);
                     });
                 });
         }

--- a/src/app/components/pending-cases/pendingcase.service.js
+++ b/src/app/components/pending-cases/pendingcase.service.js
@@ -5,7 +5,7 @@
         .service('cmPendingCaseService', cmPendingCaseService);
 
     /* ngInject */
-    function cmPendingCaseService(DARUnReviewed, ConsentUnReviewed, DataRequestPendingCases, ConsentPendingCases, MatchSummaryCases ,ConsentSummaryCases, DataRequestSummaryCases, DataOwnerUnReviewed) {
+    function cmPendingCaseService(DARUnReviewed, ConsentUnReviewed, DataRequestPendingCases, ConsentPendingCases, MatchSummaryCases ,ConsentSummaryCases, DataRequestSummaryCases, DataOwnerUnReviewed, $sce) {
 
         /**
          * Finding data request pending cases for the specified user id
@@ -39,6 +39,7 @@
                     vm.electionsList.dul = data;
                     vm.electionsList.dul.forEach(
                         function countCollectVotes(dul) {
+                            dul.consentGroupName = $sce.trustAsHtml(dul.consentGroupName);
                             if (dul.alreadyVoted === false) {
                                 vm.totalDulPendingVotes += 1;
                             }

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -1048,8 +1048,6 @@ small {
 
 .empty::before {
     content: '- -';
-    color: #777777;
-    font-size: 14px;
 }
 
 .cell-button {

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -622,6 +622,10 @@ small {
     font-weight: 300;
 }
 
+.pipe::after {
+    content: ' | ';
+}
+
 .cm-title, .cm-title-admin, .cm-subtitle, .cm-subtitle-ultimate, .cm-user-name, .cm-results-subtitle, .cm-box-title {
     color: #777777;
 }

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -1046,6 +1046,12 @@ small {
     right: 0;
 }
 
+.empty::before {
+    content: '- -';
+    color: #777777;
+    font-size: 14px;
+}
+
 .cell-button {
     width: 100%;
     text-align: center;

--- a/src/app/results-record/dul-results-record.controller.js
+++ b/src/app/results-record/dul-results-record.controller.js
@@ -80,7 +80,7 @@
         $scope.finalVote = electionReview.election.finalVote;
         $scope.voteList = chunk(electionReview.reviewVote, 2);
         $scope.chartData = getGraphData(electionReview.reviewVote);
-        $scope.consentGroupName = electionReview.consent.groupName;
+        $scope.consentGroupName = $sce.trustAsHtml(electionReview.consent.groupName);
 
         $scope.downloadDUL = function(){
             cmFilesService.getDulFileByElectionId(electionReview.consent.consentId, electionReview.election.dulName, electionReview.election.electionId);

--- a/src/app/results-record/dul-results-record.html
+++ b/src/app/results-record/dul-results-record.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 Data Use Limitations - Results Record
-                <span class="main-title-case"><b ng-show="{{consentGroupName}}">{{consentGroupName}}  | </b>{{consentName}}</span>
+                <span class="main-title-case"><b ng-show="consentGroupName" ng-bind-html="consentGroupName"></b> | {{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/results-record/dul-results-record.html
+++ b/src/app/results-record/dul-results-record.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 Data Use Limitations - Results Record
-                <span class="main-title-case"><b ng-show="consentGroupName" ng-bind-html="consentGroupName"></b> | {{consentName}}</span>
+                <span class="main-title-case"><b ng-show="consentGroupName" class="pipe" ng-bind-html="consentGroupName"></b>{{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/results-record/dul-results-record.html
+++ b/src/app/results-record/dul-results-record.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 Data Use Limitations - Results Record
-                <span class="main-title-case"><b>{{consentGroupName}}</b> | {{consentName}}</span>
+                <span class="main-title-case"><b ng-show="{{consentGroupName}}">{{consentGroupName}}  | </b>{{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/review-results/dul-preview-results.controller.js
+++ b/src/app/review-results/dul-preview-results.controller.js
@@ -22,7 +22,7 @@
         $scope.consentName = consent.name;
         $scope.downloadUrl = apiUrl + 'consent/' + $scope.consent.consentId + '/dul';
         $scope.dulName = dulName;
-        $scope.consentGroupName = consent.groupName;
+        $scope.consentGroupName = $sce.trustAsHtml(consent.groupName);
         $scope.dataUseLetter = $scope.consent.dataUseLetter;
         $scope.structuredDataUseLetter = $sce.trustAsHtml($scope.consent.translatedUseRestriction);
         $rootScope.path = 'dul-preview-results';

--- a/src/app/review-results/dul-preview-results.html
+++ b/src/app/review-results/dul-preview-results.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 Data Use Limitations Congruence Preview
-                <span class="main-title-case"><b ng-show="consentGroupName" ng-bind-html="consentGroupName"></b> | {{consentName}}</span>
+                <span class="main-title-case"><b ng-show="consentGroupName" class="pipe" ng-bind-html="consentGroupName"></b>{{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/review-results/dul-preview-results.html
+++ b/src/app/review-results/dul-preview-results.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 Data Use Limitations Congruence Preview
-                <span class="main-title-case"><b ng-show="{{consentGroupName}}">{{consentGroupName}}  | </b>{{consentName}}</span>
+                <span class="main-title-case"><b ng-show="consentGroupName" ng-bind-html="consentGroupName"></b> | {{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/review-results/dul-preview-results.html
+++ b/src/app/review-results/dul-preview-results.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 Data Use Limitations Congruence Preview
-                <span class="main-title-case"><b>{{consentGroupName}}</b> | {{consentName}}</span>
+                <span class="main-title-case"><b ng-show="{{consentGroupName}}">{{consentGroupName}}  | </b>{{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/review-results/dul-review-results.controller.js
+++ b/src/app/review-results/dul-review-results.controller.js
@@ -71,7 +71,7 @@
         $scope.downloadUrl = apiUrl + 'consent/' + electionReview.consent.consentId + '/dul';
         $scope.dulName = electionReview.election.dulName;
         $scope.consentName = electionReview.consent.name;
-        $scope.consentGroupName = electionReview.consent.groupName;
+        $scope.consentGroupName =  $sce.trustAsHtml(electionReview.consent.groupName);
         $scope.structuredDataUseLetter = $sce.trustAsHtml(electionReview.election.translatedUseRestriction);
         $scope.positiveVote = positiveVote;
         $scope.logVote = logVote;

--- a/src/app/review-results/dul-review-results.html
+++ b/src/app/review-results/dul-review-results.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 {{ hasAdminRole ? "" : "Collect" }} Votes for Data Use Limitations Congruence Review
-                <span class="main-title-case"><b>{{consentGroupName}}</b> | {{consentName}}</span>
+                <span class="main-title-case"><b ng-show="{{consentGroupName}}">{{consentGroupName}}  | </b>{{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/review-results/dul-review-results.html
+++ b/src/app/review-results/dul-review-results.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 {{ hasAdminRole ? "" : "Collect" }} Votes for Data Use Limitations Congruence Review
-                <span class="main-title-case"><b ng-show="consentGroupName" ng-bind-html="consentGroupName"> </b> | {{consentName}}</span>
+                <span class="main-title-case"><b ng-show="consentGroupName" class="pipe" ng-bind-html="consentGroupName"></b>{{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/review-results/dul-review-results.html
+++ b/src/app/review-results/dul-review-results.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 {{ hasAdminRole ? "" : "Collect" }} Votes for Data Use Limitations Congruence Review
-                <span class="main-title-case"><b ng-show="{{consentGroupName}}">{{consentGroupName}}  | </b>{{consentName}}</span>
+                <span class="main-title-case"><b ng-show="consentGroupName" ng-bind-html="consentGroupName"> </b> | {{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/review/dul-review.controller.js
+++ b/src/app/review/dul-review.controller.js
@@ -16,7 +16,8 @@
         $scope.consentDulName = election.dulName;
         $scope.consentSDul = $sce.trustAsHtml(election.translatedUseRestriction);
         $scope.consentName = consent.name;
-        $scope.consentGroupName = consent.groupName;
+        $scope.consentGroupName = $sce.trustAsHtml(consent.groupName);
+        
         $scope.voteStatus = vote.vote;
         $scope.isFormDisabled = (election.status === 'Closed');
         $scope.rationale = vote.rationale;

--- a/src/app/review/dul-review.html
+++ b/src/app/review/dul-review.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 Data Use Limitations Congruence Review
-                <span class="main-title-case"><b>{{consentGroupName}}</b> | {{consentName}}</span>
+                <span class="main-title-case"><b ng-show="{{consentGroupName}}">{{consentGroupName}}  | </b>{{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/review/dul-review.html
+++ b/src/app/review/dul-review.html
@@ -5,7 +5,7 @@
             <img src="assets/images/icon_dul.png" alt="Data Use Limitations icon" class="cm-icons main-icon-title">
             <h2 class="main-title margin-sm dul-color">
                 Data Use Limitations Congruence Review
-                <span class="main-title-case"><b ng-show="{{consentGroupName}}">{{consentGroupName}}  | </b>{{consentName}}</span>
+                <span class="main-title-case"><b ng-show="consentGroupName" class="pipe" ng-bind-html="consentGroupName"></b>{{consentName}}</span>
             </h2>
         </div>
         <div class="col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding">

--- a/src/app/reviewed-cases/reviewed-cases.controller.js
+++ b/src/app/reviewed-cases/reviewed-cases.controller.js
@@ -5,7 +5,7 @@
         .controller('ReviewedCases', ReviewedCases);
 
     /* ngInject */
-    function ReviewedCases(reviewedConsents, reviewedDRs, $scope, $rootScope, $stateParams) {
+    function ReviewedCases(reviewedConsents, reviewedDRs, $scope, $rootScope, $stateParams, $sce) {
 
         var vm = this;
         vm.electionsList = {'dul': [], 'access': []};
@@ -49,6 +49,7 @@
             vm.electionsList.dul.forEach(function(election) {
                 var str = election.displayId;
                 str = str.replace(regex, ' ');
+                election.consentGroupName = $sce.trustAsHtml(election.consentGroupName);
                 election.ct = String(election.displayId) + ' ' + String(election.version < 10 ? '0' + election.version : election.version);
                 election.cts = str + ' ' + String(election.version < 10 ? '0' + election.version : election.version);
             });

--- a/src/app/reviewed-cases/reviewed-cases.html
+++ b/src/app/reviewed-cases/reviewed-cases.html
@@ -40,7 +40,7 @@
             <div dir-paginate="election in ReviewedCases.electionsList.dul | orderBy:sortBy:reverse | filter: searchDULcases | itemsPerPage:5" pagination-id="dulCases" current-page="currentDulPage">
                 <div class="grid-row">
                     <div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.displayId}}">{{election.displayId}}</div>
-                    <div class="col-2 cell-body text" title="{{election.consentGroupName}}">{{election.consentGroupName}}</div>
+                    <div class="col-2 cell-body text" ng-class="{empty : !election.consentGroupName}" title="{{election.consentGroupName}}">{{election.consentGroupName}}</div>
                     <div class="col-1 cell-body text">{{election.version < 10 ? '0' + election.version : election.version}}</div>
                     <div class="col-1 cell-body text">{{election.finalVoteDate}}</div>
                     <div class="col-1 cell-body text f-center bold">

--- a/src/app/user-console/user-console.html
+++ b/src/app/user-console/user-console.html
@@ -39,7 +39,7 @@
                         <hr class="pvotes-separator">
                         <div class="row pvotes-main-list">
                             <div class="col-lg-2 col-md-2 col-sm-2 col-xs-3 pvotes-list-id" title="{{pendingCase.frontEndId}}">{{pendingCase.frontEndId}}</div>
-                            <div class="col-lg-4 col-md-4 col-sm-4 col-xs-3 pvotes-list-id" title="{{pendingCase.consentGroupName}}">{{pendingCase.consentGroupName}}</div>
+                            <div class="col-lg-4 col-md-4 col-sm-4 col-xs-3 pvotes-list-id" ng-class="{empty : !pendingCase.consentGroupName}" title="{{pendingCase.consentGroupName}}">{{pendingCase.consentGroupName}}</div>
                             <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2 pvotes-list bold">
                                 <span ng-if="pendingCase.isReminderSent == true">URGENT!</span>
                                 <span ng-if="pendingCase.status == 'pending' && pendingCase.isReminderSent != true">Pending</span>


### PR DESCRIPTION
Recently created Consent Group Name field is a non-required field, that may not be present in every consent record. For that reason, we need to better handle its possible absence.

In election related pages (dul-preview, dul-review, dul-review-results and dul-result-records), the pipe that separates this data from Consent Id, should only appear if there is a Consent Group Name.
In table layout pages (manage-dul, chair-console, user-console and reviewed cases records), if there is no Consent Group Name, we should display "- -".
This new field comes from ORSP, and it's quite possible that it contains the ":" character. Currently the UI is not supporting this character, and is throwing a console error on those cases. We need to handle this situation to allow that character without any errors on console.