### PR TITLE
BTRX - 242 - Re-set Consent status when ORSP pushes updated content

### DIFF
--- a/src/app/admin-manage/admin-manage-dul.html
+++ b/src/app/admin-manage/admin-manage-dul.html
@@ -37,7 +37,8 @@
 
         <div dir-paginate="election in AdminManage.electionsList.dul | filter: searchDUL | itemsPerPage:10" current-page="AdminManage.currentDULPage">
             <div class="grid-9-row pushed-2">
-                <div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.consentName}}">{{election.consentName}}</div>
+                <!--<div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.consentName}}">{{election.consentName}}</div>-->
+                <div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.consentName}}"><a>{{election.consentName}}</a></div>
                 <div class="col-2 cell-body text" ng-class="{empty : !election.groupName}" title="{{election.groupName}}">{{election.groupName}}</div>
                 <div class="col-1 cell-body text" ng-class="{empty : !election.version}">{{election.version}}</div>
                 <div class="col-1 cell-body text">{{election.createDate | date:'yyyy-MM-dd'}}</div>
@@ -60,6 +61,9 @@
                     </button>
                     <button ng-disabled="election.electionStatus != 'un-reviewed'" ng-click="AdminManage.openDelete(election.consentId)">
                         <span class="glyphicon glyphicon-trash caret-margin" aria-hidden="true" tooltip-class="tooltip-class" tooltip-trigger tooltip-placement="right" tooltip="Delete record"></span>
+                    </button>
+                    <button ng-disabled="election.updateStatus != true">
+                        <span class="glyphicon glyphicon-alert caret-margin" aria-hidden="true" tooltip-class="tooltip-class" tooltip-trigger tooltip-placement="right" tooltip="Consent has been updated"></span>
                     </button>
                 </div>
             </div>

--- a/src/app/admin-manage/admin-manage-dul.html
+++ b/src/app/admin-manage/admin-manage-dul.html
@@ -37,8 +37,7 @@
 
         <div dir-paginate="election in AdminManage.electionsList.dul | filter: searchDUL | itemsPerPage:10" current-page="AdminManage.currentDULPage">
             <div class="grid-9-row pushed-2">
-                <!--<div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.consentName}}">{{election.consentName}}</div>-->
-                <div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.consentName}}"><a>{{election.consentName}}</a></div>
+                <div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.consentName}}"><a ng-click="AdminManage.open(election.consentId, 'dul_preview_results', null)">{{election.consentName}}</a></div>
                 <div class="col-2 cell-body text" ng-class="{empty : !election.groupName}" title="{{election.groupName}}">{{election.groupName}}</div>
                 <div class="col-1 cell-body text" ng-class="{empty : !election.version}">{{election.version}}</div>
                 <div class="col-1 cell-body text">{{election.createDate | date:'yyyy-MM-dd'}}</div>

--- a/src/app/admin-manage/admin-manage-dul.html
+++ b/src/app/admin-manage/admin-manage-dul.html
@@ -34,10 +34,13 @@
         </div>
 
         <hr class="pvotes-main-separator">
-
+        
         <div dir-paginate="election in AdminManage.electionsList.dul | filter: searchDUL | itemsPerPage:10" current-page="AdminManage.currentDULPage">
-            <div class="grid-9-row pushed-2">
-                <div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.consentName}}"><a ng-click="AdminManage.open(election.consentId, 'dul_preview_results', null)">{{election.consentName}}</a></div>
+            <div class="grid-9-row pushed-2" ng-class="{'list-highlighted': election.updateStatus}">               
+                <div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.consentName}}">
+                    <span ng-if="election.updateStatus" class="glyphicon glyphicon-exclamation-sign list-highlighted-item dul-color" tooltip="Consent has been updated" aria-hidden="true" tooltip-class="tooltip-class" tooltip-trigger tooltip-placement="right"></span>
+                    <a ng-click="AdminManage.open(election.consentId, 'dul_preview_results', null)">{{election.consentName}}</a>
+                </div>
                 <div class="col-2 cell-body text" ng-class="{empty : !election.groupName}" title="{{election.groupName}}">{{election.groupName}}</div>
                 <div class="col-1 cell-body text" ng-class="{empty : !election.version}">{{election.version}}</div>
                 <div class="col-1 cell-body text">{{election.createDate | date:'yyyy-MM-dd'}}</div>
@@ -60,9 +63,6 @@
                     </button>
                     <button ng-disabled="election.electionStatus != 'un-reviewed'" ng-click="AdminManage.openDelete(election.consentId)">
                         <span class="glyphicon glyphicon-trash caret-margin" aria-hidden="true" tooltip-class="tooltip-class" tooltip-trigger tooltip-placement="right" tooltip="Delete record"></span>
-                    </button>
-                    <button ng-disabled="election.updateStatus != true">
-                        <span class="glyphicon glyphicon-alert caret-margin" aria-hidden="true" tooltip-class="tooltip-class" tooltip-trigger tooltip-placement="right" tooltip="Consent has been updated"></span>
                     </button>
                 </div>
             </div>

--- a/src/app/admin-manage/admin-manage-dul.html
+++ b/src/app/admin-manage/admin-manage-dul.html
@@ -34,12 +34,12 @@
         </div>
 
         <hr class="pvotes-main-separator">
-        
+
         <div dir-paginate="election in AdminManage.electionsList.dul | filter: searchDUL | itemsPerPage:10" current-page="AdminManage.currentDULPage">
-            <div class="grid-9-row pushed-2" ng-class="{'list-highlighted': election.updateStatus}">               
+            <div class="grid-9-row pushed-2" ng-class="{'list-highlighted': election.updateStatus}">
                 <div class="col-2 cell-body text" ng-class="{flagged : election.archived}" title="{{election.consentName}}">
                     <span ng-if="election.updateStatus" class="glyphicon glyphicon-exclamation-sign list-highlighted-item dul-color" tooltip="Consent has been updated" aria-hidden="true" tooltip-class="tooltip-class" tooltip-trigger tooltip-placement="right"></span>
-                    <a ng-click="AdminManage.open(election.consentId, 'dul_preview_results', null)">{{election.consentName}}</a>
+                    <a ng-click="AdminManage.open(election.consentId, 'dul_preview_results', null, true)">{{election.consentName}}</a>
                 </div>
                 <div class="col-2 cell-body text" ng-class="{empty : !election.groupName}" title="{{election.groupName}}">{{election.groupName}}</div>
                 <div class="col-1 cell-body text" ng-class="{empty : !election.version}">{{election.version}}</div>
@@ -48,10 +48,10 @@
                     <button class="cell-button hover-color" ng-disabled="election.electionStatus != 'un-reviewed' || !election.editable" ng-click="AdminManage.editDul(election.consentId)">Edit</button>
                 </div>
                 <div class="col-1 cell-body text f-center bold">
-                    <span ng-if="election.electionStatus == 'un-reviewed'"><a ng-click="AdminManage.open(election.consentId, 'dul_preview_results', null)">Un-reviewed</a></span>
-                    <span ng-if="election.electionStatus == 'Open'"><a ng-click="AdminManage.open(election.consentId, 'dul_review_results', null)">Open</a></span>
-                    <span ng-if="election.electionStatus == 'Canceled'"><a ng-click="AdminManage.open(election.consentId, 'dul_preview_results', null)">Canceled</a></span>
-                    <span ng-if="election.electionStatus == 'Closed'"><a ng-click="AdminManage.open(null, 'dul_results_record', election.electionId)">Reviewed</a></span>
+                    <span ng-if="election.electionStatus == 'un-reviewed'"><a ng-click="AdminManage.open(election.consentId, 'dul_preview_results', null, false)">Un-reviewed</a></span>
+                    <span ng-if="election.electionStatus == 'Open'"><a ng-click="AdminManage.open(election.consentId, 'dul_review_results', null, false)">Open</a></span>
+                    <span ng-if="election.electionStatus == 'Canceled'"><a ng-click="AdminManage.open(election.consentId, 'dul_preview_results', null, false)">Canceled</a></span>
+                    <span ng-if="election.electionStatus == 'Closed'"><a ng-click="AdminManage.open(null, 'dul_results_record', election.electionId, false)">Reviewed</a></span>
                 </div>
                 <div class="col-1 cell-body f-center">
                     <button ng-if="election.electionStatus != 'Open'" ng-disabled="!election.editable" class="cell-button hover-color" ng-click="AdminManage.openCreate(election)">Create</button>

--- a/src/app/admin-manage/admin-manage.controller.js
+++ b/src/app/admin-manage/admin-manage.controller.js
@@ -152,7 +152,7 @@
             });
         }
 
-        function open(consentId, url, electionId) {
+        function open(consentId, url, electionId, showConsent) {
             cmConsentService.setShowConsent(showConsent);
             $rootScope.currentDULPage = vm.currentDULPage;
             if (electionId === null) {

--- a/src/app/admin-manage/admin-manage.controller.js
+++ b/src/app/admin-manage/admin-manage.controller.js
@@ -158,7 +158,7 @@
                 $state.go(url, { consentId: consentId });
             } else {
                 $state.go(url, { electionId: electionId });
-            }            
+            }
         }
     }
 })();

--- a/src/app/admin-manage/admin-manage.controller.js
+++ b/src/app/admin-manage/admin-manage.controller.js
@@ -153,8 +153,9 @@
         }
 
         function open(consentId, url, electionId) {
+            cmConsentService.setShowConsent(showConsent);
             $rootScope.currentDULPage = vm.currentDULPage;
-            if(electionId === null) {
+            if (electionId === null) {
                 $state.go(url, { consentId: consentId });
             } else {
                 $state.go(url, { electionId: electionId });

--- a/src/app/components/consent/consent.service.js
+++ b/src/app/components/consent/consent.service.js
@@ -6,7 +6,8 @@
 
     /* ngInject */
     function cmConsentService(ConsentInvalidRestriction, ConsentResource, DeleteConsentResource, ConsentDulResource, ConsentManageResource, CreateConsentResource, CreateDulResource, UpdateConsentResource, $sce) {
-
+        // Variable to display consent data in dul preview results
+        var showConsent = false;
         /**
          * Find data for the consent related to the consentId sent as a parameter
          * @param consentId
@@ -77,7 +78,23 @@
             return DeleteConsentResource.Delete({consentId: consentId}).$promise;
         }
 
+        function setShowConsent(show) {
+            showConsent = show;
+        }
+
+        function getShowConsent() {
+            return showConsent;
+        }
+
         return {
+            setShowConsent: function(show) {
+                return setShowConsent(show);
+            },
+
+            getShowConsent: function() {
+                return getShowConsent();
+            },
+
             findConsent: function (id) {
                 return findConsentById(id);
             },

--- a/src/app/components/consent/consent.service.js
+++ b/src/app/components/consent/consent.service.js
@@ -36,7 +36,6 @@
                         election.ct = election.consentName + ' ' + election.version;
                         election.cts = str + ' ' + election.version;
                         election.groupName = $sce.trustAsHtml(election.groupName);
-                        election.updateStatus = election.updateStatus;
                     });
                 });
         }

--- a/src/app/components/consent/consent.service.js
+++ b/src/app/components/consent/consent.service.js
@@ -35,6 +35,7 @@
                         election.ct = election.consentName + ' ' + election.version;
                         election.cts = str + ' ' + election.version;
                         election.groupName = $sce.trustAsHtml(election.groupName);
+                        election.updateStatus = election.updateStatus;
                     });
                 });
         }
@@ -83,6 +84,7 @@
             findDataUseLetterForConsent: function (id) {
                 return findDulForConsent(id);
             },
+
             findConsentManage: function (vm) {
                 return findConsentManage(vm);
             },

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -3630,7 +3630,7 @@ tags-input .tags .tag-item{
 }
 
 .grid-9-row .col-2 {
-    width: 22.22%;
+    width: 20.22%;
 }
 
 .grid-row .col-1, .grid-row .col-2, .grid-row .col-3, .grid-row .col-4, .grid-row .col-5, .grid-row .col-6, .grid-row .col-7, .grid-row .col-8{

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -1362,13 +1362,13 @@ input[type=checkbox]:checked + label:before{
 }
 
 .list-highlighted{
-    background-color: rgba(96, 59, 155, 0.05);
+    background-color: rgba(204, 204, 204, 0.25);
 }
 
 .list-highlighted .glyphicon-exclamation-sign{
-    margin: 0 10px 0 5px;
+    margin: 0 5px 0 0;
     font-size: 1.2em;
-    line-height: 22px;
+    line-height: 20px;
 }
 
 .list-highlighted .glyphicon-download-alt{
@@ -3607,7 +3607,8 @@ tags-input .tags .tag-item{
 
 .grid-row,
 .grid-9-row {
-    display: inline-block;
+    display: inline-flex;
+    min-height: 43px;
     width: 100%;
     margin: 0;
     padding: 0;
@@ -3630,7 +3631,7 @@ tags-input .tags .tag-item{
 }
 
 .grid-9-row .col-2 {
-    width: 20.22%;
+    width: 22.22%;
 }
 
 .grid-row .col-1, .grid-row .col-2, .grid-row .col-3, .grid-row .col-4, .grid-row .col-5, .grid-row .col-6, .grid-row .col-7, .grid-row .col-8{

--- a/src/app/review-results/dul-preview-results.controller.js
+++ b/src/app/review-results/dul-preview-results.controller.js
@@ -4,12 +4,13 @@
     angular.module('cmReviewResults')
         .controller('DulPreviewResults', DulPreviewResults);
 
-    function DulPreviewResults($sce, apiUrl, $scope, $rootScope, $modal, $state, consent, cmFilesService, electionReview) {
+    function DulPreviewResults($sce, apiUrl, $scope, $rootScope, $modal, $state, consent, cmFilesService, electionReview, cmConsentService) {
         $scope.hasAdminRole = $rootScope.hasRole($rootScope.userRoles.admin);
         $scope.consent = consent;
         $scope.election = electionReview.election;
+        var showConsent = cmConsentService.getShowConsent();
         var dulName;
-        if (typeof electionReview.election === 'undefined' || $scope.consent.updated){
+        if (typeof electionReview.election === 'undefined' || showConsent) {
             dulName = $scope.consent.dulName;
             $scope.dataUseLetter = $scope.consent.dataUseLetter;
             $scope.structuredDataUseLetter = $sce.trustAsHtml($scope.consent.translatedUseRestriction);
@@ -24,7 +25,6 @@
         $scope.dulName = dulName;
         $scope.consentGroupName = $sce.trustAsHtml(consent.groupName);
         $scope.dataUseLetter = $scope.consent.dataUseLetter;
-        $scope.structuredDataUseLetter = $sce.trustAsHtml($scope.consent.translatedUseRestriction);
         $rootScope.path = 'dul-preview-results';
         $scope.downloadDUL = function(){
             cmFilesService.getDULFile($scope.consent.consentId, $scope.consent.dulName);

--- a/src/app/review-results/dul-preview-results.controller.js
+++ b/src/app/review-results/dul-preview-results.controller.js
@@ -24,7 +24,6 @@
         $scope.downloadUrl = apiUrl + 'consent/' + $scope.consent.consentId + '/dul';
         $scope.dulName = dulName;
         $scope.consentGroupName = $sce.trustAsHtml(consent.groupName);
-        $scope.dataUseLetter = $scope.consent.dataUseLetter;
         $rootScope.path = 'dul-preview-results';
         $scope.downloadDUL = function(){
             cmFilesService.getDULFile($scope.consent.consentId, $scope.consent.dulName);

--- a/src/app/review-results/dul-preview-results.controller.js
+++ b/src/app/review-results/dul-preview-results.controller.js
@@ -9,7 +9,7 @@
         $scope.consent = consent;
         $scope.election = electionReview.election;
         var dulName;
-        if (typeof electionReview.election === 'undefined'){
+        if (typeof electionReview.election === 'undefined' || $scope.consent.updated){
             dulName = $scope.consent.dulName;
             $scope.dataUseLetter = $scope.consent.dataUseLetter;
             $scope.structuredDataUseLetter = $sce.trustAsHtml($scope.consent.translatedUseRestriction);


### PR DESCRIPTION
## Addresses Jira Story:
[BTRX-242-Re-set Consent status when ORSP pushes updated content](https://broadinstitute.atlassian.net/browse/BTRX-242) 

## Changes in this PR:
- Ui modifications to label a consent update status in Manage DUL page, and make clickeable its name.
- Create a service to share a variable that indicates when the navigation comes from the consent name in  Manage DUL table to Preview Results page.
 
## Note:
This PR is related to this backend branch PR [lf-BTRX-242-ResetConsentStatus](https://github.com/DataBiosphere/consent/pull/285)

---